### PR TITLE
Hardware driven transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,31 @@
-pycyborg
-========
+#pycyborg
 
-Python library for the cyborg ambx gaming lights 
-(http://www.cyborggaming.com/prod/ambx.htm)
+Python library for the cadcatz cyborg ambx gaming lights 
+(http://www.ambx.com/product/cyborg-gaming-lights)
 
-
-Status:
+##Status
  - protocol reverse engineering: done
  - simple demo without library: done
  - library: done
  - boblight interface: done
  - installer: done
- - tested platforms: Linux(Arch,Ubuntu,OpenElec,Raspbian) , Mac OS X 10.6.8
+ - tested platforms: Linux(Arch,Ubuntu,OpenElec,Raspbian) , Mac OS X
 
 Requires : 
- - libusb ( http://www.libusb.org/ ) and pyusb 1.0 ( https://github.com/walac/pyusb/ )
+ - libusb 1.0 ( http://www.libusb.org/ ) and pyusb  ( https://github.com/walac/pyusb/ )
 
+##scripts
 
-scripts
--------
+* ```identify.py``` : activate all cyborg gaming lights and print out some information
+* ```setcolor.py``` : control the gaming lights from the shell (from bash scripts etc) 
+* ```boblight.py``` : boblight interface
+* ```lightpack-prismatik.py``` : [lightpack](http://lightpack.tv/index.php) client
+* a few demo scripts are available in the ```demo``` folder 
 
-"identify.py" : to activate all cyborg gaming lights and print out some information (position, intensity)
-
-"setcolor.py" : control the gaming lights from the shell (from bash scripts etc) 
-
-"boblight.py" : boblight interface
-
-a few demo scripts are available in the demo folder 
-
-getting started
----------------
+##getting started
 
 * install libusb-1.0
 * install pyusb 1.0 ( use your distro's package or directly from  github: https://github.com/walac/pyusb/ )
-
 * get the source
 
 either as package:
@@ -58,7 +50,7 @@ install the package and reload udev rules
 * test
 
 this should flash your gaming lights and print out some info. 
-if you skipped step 2 you must run this as root, eg. sudo python identify.py or you will get USBError: [Errno 13] Access denied (insufficient permissions)
+if you skipped step 2 you must run this as root, eg. sudo python identify.py or you will get ```USBError: [Errno 13] Access denied``` (insufficient permissions)
 
     python identify.py
  
@@ -74,8 +66,7 @@ console output should be similar to this:
     <Cyborg position=S v_pos=low intensity=50%>
 
 
-boblight
---------
+##boblight
 
 To control the cyborg lights from boblight (http://code.google.com/p/boblight/), use a config file like below
 (change the path in 'output' to where you checked out pycyborg)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Python library for the cadcatz cyborg ambx gaming lights
  - library: done
  - boblight interface: done
  - installer: done
- - tested platforms: Linux(Arch,Ubuntu,OpenElec,Raspbian) , Mac OS X
+ - tested platforms: Linux(Arch,Ubuntu,OpenElec,Raspbian) , Mac OS X, Win10
 
 Requires : 
- - libusb 1.0 ( http://www.libusb.org/ ) and pyusb  ( https://github.com/walac/pyusb/ )
+ - libusb 1.0 ( http://www.libusb.org/ ) or libusb-win32 (http://zadig.akeo.ie/)
+ - pyusb  ( https://github.com/walac/pyusb/ )
 
 ##scripts
 
@@ -24,7 +25,7 @@ Requires :
 
 ##getting started
 
-* install libusb-1.0
+* install libusb-1.0 (or libusb-win32 via zadig)
 * install pyusb 1.0 ( use your distro's package or directly from  github: https://github.com/walac/pyusb/ )
 * get the source
 

--- a/openelec.md
+++ b/openelec.md
@@ -26,9 +26,9 @@ step-by-step
  * extract `master.zip`
  * delete `master.zip`
  * you should now have two folders `pyusb-master` and `pycyborg-master`
- * copy both folders via smb to the openelec box into `Userdata`
+ * copy both folders via smb to the openelec box into `userdata`
 
-still over smb, open the folder `Userdata/addon_data/service.multimedia.boblightd`
+still over smb, open the folder `userdata/addon_data/service.multimedia.boblightd`
 and create a new file `boblight.conf` with the following content:
 
 
@@ -38,7 +38,7 @@ and create a new file `boblight.conf` with the following content:
 	
 	[device]
 	name cyborg_ambx
-	output "/storage/.xbmc/userdata/pycyborg-master/boblight.py"
+	output "/storage/.kodi/userdata/pycyborg-master/boblight.py"
 	channels 6
 	type popen
 	interval 500000
@@ -77,12 +77,12 @@ and create a new file `boblight.conf` with the following content:
 
 since we can not install pyusb into a systemfolder where pycyborg can find it, we need to symlink it directly:
 
-	cd ~/.xbmc/userdata/pycyborg-master/
+	cd ~/.kodi/userdata/pycyborg-master/
 	ln -s ../pyusb-master/usb
 	
 now it's time to test if the gaming lights are working:
 
-	cd ~/.xbmc/userdata/pycyborg-master/
+	cd ~/.kodi/userdata/pycyborg-master/
 	./identify.py
 	
 if you see the lights flashing, another reboot should do the trick and enable boblight

--- a/pycyborg/__init__.py
+++ b/pycyborg/__init__.py
@@ -110,7 +110,7 @@ class Cyborg(object):
         g=self.assert_int_255(g)
         b=self.assert_int_255(b)
         #make this a no-op if we already are showing this color
-        if not force and (r==self.r and b==self.b and b==self.b):
+        if not force and (r==self.r and g==self.g and b==self.b):
             return None
         
         ret=self.usbdev.ctrl_transfer(bmRequestType=0x21, bRequest=0x09, wValue=0x03a2, wIndex=0, data_or_wLength=[0xa2,0x00,r,g,b,0x00,0x00,0x00,0x00])

--- a/pycyborg/__init__.py
+++ b/pycyborg/__init__.py
@@ -166,7 +166,12 @@ class Cyborg(object):
 
 def is_openelec():
     """Returns True if we are on a openelec system (which means read-only root fs)"""
-    return os.path.exists("/etc/openelec-release")
+    if os.path.exists("/etc/openelec-release"):
+        return True
+    osrelfile="/etc/os-release"
+    if os.path.exists(osrelfile) and "openelec" in open(osrelfile,'r').read().lower():
+        return True
+    return False
 
 def get_all_cyborgs(lights_off=True):
     """Search usb bus for cyborg gaming ligts and return all initialized Cyborg objects"""
@@ -177,7 +182,7 @@ def get_all_cyborgs(lights_off=True):
     retlist=[]
     #patch the dll loader for openelec systems (or we'll get no backend available error)
     if is_openelec():
-        def openelec_loader():     
+        def openelec_loader(find_library=None):
             return ctypes.CDLL('libusb-1.0.so')
         
         libusb1._load_library=openelec_loader

--- a/setcolor.py
+++ b/setcolor.py
@@ -9,6 +9,13 @@ from optparse import OptionParser
 import sys
 from pycyborg import get_all_cyborgs,POSITION
 
+colormap={
+    'off':(0,0,0),
+    'red':(255,0,0),
+    'green':(0,255,0),
+    'blue':(0,0,255),
+}
+
 if __name__=='__main__':
     optionparser=OptionParser()
     optionparser.add_option("-n",type="int", dest="num",help="only change n-th device color (start at 0)")
@@ -17,21 +24,20 @@ if __name__=='__main__':
     optionparser.add_option("-v",dest="verbose",action="store_true",default=False, help="be verbose")
 
     (options,pargs) = optionparser.parse_args()
-    
-    #pargs must be 3 values
-    if len(pargs)!=3:
+    if len(pargs)==1 and pargs[0].lower() in colormap:
+        r,g,b=colormap[pargs[0].lower()]
+    elif len(pargs)==3:
+        try:
+            r,g,b=int(pargs[0]),int(pargs[1]),int(pargs[2])
+        except:
+            print "r g b must be integers 0-255"
+            optionparser.print_help()
+            sys.exit(1)
+    else:
         print "missing r/g/b values"
         optionparser.print_help()
         sys.exit(1)
-    
-    try:
-        r,g,b=int(pargs[0]),int(pargs[1]),int(pargs[2])
-    except:
-        print "r g b must be integers 0-255"
-        optionparser.print_help()
-        sys.exit(1)
-        
-    
+
     if r<0 or r>255 or g<0 or g>255 or b<0 or b>255:
         print "r g b must be integers 0-255"
         optionparser.print_help()
@@ -77,7 +83,7 @@ if __name__=='__main__':
     
     if options.verbose:
         print "Setting color to %s,%s,%s on %s cyborg(s)"%(r,g,b,len(cyborgs))
-    
+
     #cyborg candidate list complete, perform the update
     for cy in cyborgs:
         if options.verbose:

--- a/setcolor.py
+++ b/setcolor.py
@@ -14,7 +14,8 @@ if __name__=='__main__':
     optionparser.add_option("-n",type="int", dest="num",help="only change n-th device color (start at 0)")
     optionparser.add_option("-p",dest="position",help="only search for devices at the specified position. possible values are: center,n,ne,e,se,s,sw,w,nw")
     optionparser.add_option("-i",type="int", dest="intensity",help="set intensity (0-100)")
-    
+    optionparser.add_option("-v",dest="verbose",action="store_true",default=False, help="be verbose")
+
     (options,pargs) = optionparser.parse_args()
     
     #pargs must be 3 values
@@ -54,6 +55,8 @@ if __name__=='__main__':
     
     
     cyborgs=get_all_cyborgs(lights_off=False)
+    if options.verbose:
+        print "Found %s cyborgs"%len(cyborgs)
     
     #filter by position
     if pos!=None:
@@ -72,9 +75,13 @@ if __name__=='__main__':
             print "can not select index %s from cyborgs. I have %s"%(options.num,len(cyborgs))
             sys.exit(1)
     
+    if options.verbose:
+        print "Setting color to %s,%s,%s on %s cyborg(s)"%(r,g,b,len(cyborgs))
     
     #cyborg candidate list complete, perform the update
     for cy in cyborgs:
+        if options.verbose:
+            print "Changing : %s"%cy
         if options.intensity!=None:
             cy.set_intensity(options.intensity)
         

--- a/setcolor.py
+++ b/setcolor.py
@@ -90,15 +90,5 @@ if __name__=='__main__':
             print "Changing : %s"%cy
         if options.intensity!=None:
             cy.set_intensity(options.intensity)
-        
-        cy.set_rgb_color(r,g,b)
-            
-    
-    
-    
-    
-            
-        
-    
-    
-    
+        cy.set_rgb_color(r,g,b,force=True)
+


### PR DESCRIPTION
After some experimentation, I discovered that the Cyborg hardware includes built in support for transition timing.  It's accessed via the A2 command where a number of milliseconds to transition can be provided.  I've added a method to the class to use that functionality.  The existing software based transitions were left unchanged.

Incidentally, if you have any other data either as notes or pcaps from your reverse engineering efforts I'd be willing to take a look.  My ambx drivers quit working a few months ago, so I've no means to capture.  The hardware still works, which I only know now due to your efforts here.  Thanks!

The pull request also includes some minor fixes, logging, and doc updates.